### PR TITLE
centralizado player do youtube

### DIFF
--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -24,7 +24,7 @@ export function Video(props: VideoProps) {
 
     return (
         <div className="flex-1">
-            <div className="bg-black">
+            <div className="flex justify-center bg-black">
                 <div className="h-fill w-full max-w-[1100px] max-h-[60vh] aspect-video">
                     <Player>
                         <Youtube videoId={data.lesson.videoId} />
@@ -86,7 +86,7 @@ export function Video(props: VideoProps) {
                             <FileArrowDown size={40} />
                         </div>
                         <div className="py-6 leading-relaxed">
-                            <strong className="text-2xl">Walloaoers exclusivos</strong>
+                            <strong className="text-2xl">Wallpapers exclusivos</strong>
                             <p className="text-sm text-gray-200 mt-2">Baixe wallpapers exclusivos do Ignite Lab e personalize a sua máquina</p>
                         </div>
                         <div className="h-full p-6 flex items-center">


### PR DESCRIPTION
### O que foi feito:
Centralizado componente player do youtube

### Por que foi feito:
Para que o layout fique centralizado para telas maiores que 1080x900px

### Como foi feito:
Usando 'flex justify-center' para centralizar o componente
