### PR TITLE
Carregando video ao se inscrever

### DIFF
--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -19,7 +19,7 @@ export function Video(props: VideoProps) {
     if((!data || !data.lesson)) {
         return (
             <div className="flex-1 flex justify-center items-center">
-                <PushSpinner size={150} color="#686769" loading={data} />
+                <PushSpinner size={150} color="#686769" />
             </div>
         )
     }

--- a/src/graphql/generated.ts
+++ b/src/graphql/generated.ts
@@ -5776,6 +5776,11 @@ export type GetLessonBySlugQueryVariables = Exact<{
 
 export type GetLessonBySlugQuery = { __typename?: 'Query', lesson?: { __typename?: 'Lesson', title: string, videoId: string, description?: string | null, teacher?: { __typename?: 'Teacher', name: string, bio: string, avatarURL: string } | null } | null };
 
+export type GetLessonFirstBySlugQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GetLessonFirstBySlugQuery = { __typename?: 'Query', lessons: Array<{ __typename?: 'Lesson', slug: string }> };
+
 
 export const CreateSubscribeDocument = gql`
     mutation CreateSubscribe($name: String!, $email: String!) {
@@ -5891,3 +5896,37 @@ export function useGetLessonBySlugLazyQuery(baseOptions?: Apollo.LazyQueryHookOp
 export type GetLessonBySlugQueryHookResult = ReturnType<typeof useGetLessonBySlugQuery>;
 export type GetLessonBySlugLazyQueryHookResult = ReturnType<typeof useGetLessonBySlugLazyQuery>;
 export type GetLessonBySlugQueryResult = Apollo.QueryResult<GetLessonBySlugQuery, GetLessonBySlugQueryVariables>;
+export const GetLessonFirstBySlugDocument = gql`
+    query GetLessonFirstBySlug {
+  lessons(first: 1) {
+    slug
+  }
+}
+    `;
+
+/**
+ * __useGetLessonFirstBySlugQuery__
+ *
+ * To run a query within a React component, call `useGetLessonFirstBySlugQuery` and pass it any options that fit your needs.
+ * When your component renders, `useGetLessonFirstBySlugQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useGetLessonFirstBySlugQuery({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useGetLessonFirstBySlugQuery(baseOptions?: Apollo.QueryHookOptions<GetLessonFirstBySlugQuery, GetLessonFirstBySlugQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<GetLessonFirstBySlugQuery, GetLessonFirstBySlugQueryVariables>(GetLessonFirstBySlugDocument, options);
+      }
+export function useGetLessonFirstBySlugLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetLessonFirstBySlugQuery, GetLessonFirstBySlugQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<GetLessonFirstBySlugQuery, GetLessonFirstBySlugQueryVariables>(GetLessonFirstBySlugDocument, options);
+        }
+export type GetLessonFirstBySlugQueryHookResult = ReturnType<typeof useGetLessonFirstBySlugQuery>;
+export type GetLessonFirstBySlugLazyQueryHookResult = ReturnType<typeof useGetLessonFirstBySlugLazyQuery>;
+export type GetLessonFirstBySlugQueryResult = Apollo.QueryResult<GetLessonFirstBySlugQuery, GetLessonFirstBySlugQueryVariables>;

--- a/src/graphql/queries/get-lesson-first-by-slug-uqery.graphql
+++ b/src/graphql/queries/get-lesson-first-by-slug-uqery.graphql
@@ -1,0 +1,5 @@
+query GetLessonFirstBySlug {
+  lessons(first: 1) {
+    slug
+  }
+}

--- a/src/pages/Event.tsx
+++ b/src/pages/Event.tsx
@@ -1,18 +1,23 @@
+import { useEffect } from "react";
 import { useParams } from "react-router-dom";
 import { Header } from "../components/Header";
 import { Sidebar } from "../components/Sidebar";
 import { Video } from "../components/Video";
+import { useGetLessonFirstBySlugQuery } from "../graphql/generated";
 
 export function Event() {
     const { slug } = useParams<{slug: string}>()
-
+    const { data } = useGetLessonFirstBySlugQuery()
+    let firstScreen = ''
+    data?.lessons.map(lesson => {
+        firstScreen = lesson.slug
+    })
+    
     return (
         <div className="flex flex-col min-h-screen">
             <Header/>
             <main className="flex flex-1">
-                { slug
-                ? <Video lessonSlug={slug} /> 
-                : <div className="flex-1" /> }
+                <Video lessonSlug={!slug ? firstScreen : slug} /> 
                 <Sidebar/>
             </main>
         </div>


### PR DESCRIPTION
### O que foi feito:
Inserido o carregamento do primeiro vídeo da lista ao entrar na página de vídeos

### Por que foi feito:
Para o usuário não fique perdido ao ver uma tela preta na tela de videos sem antes selecionar um video

### Como foi feito:
Consumido do GraphQL o primeiro videoID da lista de videos
